### PR TITLE
bugfix: guard against nil message.View before calling IsValidValidato…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,5 @@ updates:
     pull-request-branch-name:
       separator: "-"
     reviewers:
-      - "dbrajovic"
-      - "zivkovicmilos"
+      - "igorcrevar"
+      - "oliverbundalo"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,6 @@ linters:
     - contextcheck # check the function whether use a non-inherited context
     - decorder # check declaration order and count of types, constants, variables and functions
     - exhaustive # check exhaustiveness of enum switch statements and map literals
-    - exportloopref # checks for pointers to enclosing loop variables
     - gocognit
     - gomoddirectives
     - nestif # Reports deeply nested if statements

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -319,79 +319,91 @@ func (i *IBFT) RunSequence(ctx context.Context, h uint64) {
 	i.log.Info("sequence started", "height", h)
 	defer i.log.Info("sequence done", "height", h)
 	defer SetMeasurementTime("sequence", startTime)
-
+	// Run the rounds until the sequence is done (block inserted or context cancelled)
 	for {
-		view := i.state.getView()
-
-		if err := i.backend.RoundStarts(view); err != nil {
-			i.log.Error("failed to handle start round callback on backend", "view", view, "err", err)
-		}
-
-		i.log.Info("round started", "round", view.Round)
-
-		currentRound := view.Round
-		ctxRound, cancelRound := context.WithCancel(ctx)
-
-		i.wg.Add(4)
-
-		// Start the round timer worker
-		go i.startRoundTimer(ctxRound, currentRound)
-
-		//	Jump round on proposals from higher rounds
-		go i.watchForFutureProposal(ctxRound)
-
-		//	Jump round on certificates
-		go i.watchForRoundChangeCertificates(ctxRound)
-
-		// Start the state machine worker
-		go i.startRound(ctxRound)
-
-		teardown := func() {
-			cancelRound()
-			i.wg.Wait()
-		}
-
-		select {
-		case ev := <-i.newProposal:
-			teardown()
-			i.log.Info("received future proposal", "round", ev.round)
-
-			i.moveToNewRound(ev.round)
-			i.acceptProposal(ev.proposalMessage)
-			i.state.setRoundStarted(true)
-			i.sendPrepareMessage(view)
-		case round := <-i.roundCertificate:
-			teardown()
-			i.log.Info("received future RCC", "round", round)
-
-			i.moveToNewRound(round)
-		case <-i.roundExpired:
-			teardown()
-			i.log.Info("round timeout expired", "round", currentRound)
-
-			newRound := currentRound + 1
-			i.moveToNewRound(newRound)
-
-			i.sendRoundChangeMessage(h, newRound)
-		case <-i.roundDone:
-			// The consensus cycle for the block height is finished.
-			// Stop all running worker threads
-			teardown()
-			i.insertBlock()
-
-			return
-		case <-ctxRound.Done():
-			teardown()
-
-			if err := i.backend.SequenceCancelled(view); err != nil {
-				i.log.Error("failed to handle sequence cancelled callback on backend", "view", view, "err", err)
-			}
-
-			i.log.Debug("sequence cancelled")
-
-			return
+		if !i.runRound(ctx, h) {
+			break
 		}
 	}
+}
+
+// runRound runs a single round of the IBFT state machine and returns true
+// to continue running additional rounds, and false when the sequence is
+// complete (block inserted or context cancelled).
+func (i *IBFT) runRound(ctx context.Context, h uint64) bool {
+	view := i.state.getView()
+	currentRound := view.Round
+
+	if err := i.backend.RoundStarts(view); err != nil {
+		i.log.Error("failed to handle start round callback on backend", "view", view, "err", err)
+	}
+
+	i.log.Info("round started", "round", currentRound)
+
+	ctxRound, cancelRound := context.WithCancel(ctx)
+	defer cancelRound()
+
+	i.wg.Add(4)
+
+	// Start the round timer worker
+	go i.startRoundTimer(ctxRound, currentRound)
+
+	//	Jump round on proposals from higher rounds
+	go i.watchForFutureProposal(ctxRound)
+
+	//	Jump round on certificates
+	go i.watchForRoundChangeCertificates(ctxRound)
+
+	// Start the state machine worker
+	go i.startRound(ctxRound)
+
+	teardown := func() {
+		cancelRound()
+		i.wg.Wait()
+	}
+
+	select {
+	case ev := <-i.newProposal:
+		teardown()
+		i.log.Info("received future proposal", "round", ev.round)
+
+		i.moveToNewRound(ev.round)
+		i.acceptProposal(ev.proposalMessage)
+		i.state.setRoundStarted(true)
+		i.sendPrepareMessage(view)
+	case round := <-i.roundCertificate:
+		teardown()
+		i.log.Info("received future RCC", "round", round)
+
+		i.moveToNewRound(round)
+	case <-i.roundExpired:
+		teardown()
+		i.log.Info("round timeout expired", "round", currentRound)
+
+		newRound := currentRound + 1
+		i.moveToNewRound(newRound)
+
+		i.sendRoundChangeMessage(h, newRound)
+	case <-i.roundDone:
+		// The consensus cycle for the block height is finished.
+		// Stop all running worker threads
+		teardown()
+		i.insertBlock()
+
+		return false
+	case <-ctxRound.Done():
+		teardown()
+
+		if err := i.backend.SequenceCancelled(view); err != nil {
+			i.log.Error("failed to handle sequence cancelled callback on backend", "view", view, "err", err)
+		}
+
+		i.log.Debug("sequence cancelled")
+
+		return false
+	}
+
+	return true
 }
 
 // startRound runs the state machine loop for the current round
@@ -1124,13 +1136,13 @@ func (i *IBFT) AddMessage(message *proto.IbftMessage) {
 
 // isAcceptableMessage checks if the message can even be accepted
 func (i *IBFT) isAcceptableMessage(message *proto.IbftMessage) bool {
-	//	Make sure the message sender is ok
-	if !i.backend.IsValidValidator(message) {
+	// Invalid messages are discarded
+	if message == nil || message.View == nil {
 		return false
 	}
 
-	// Invalid messages are discarded
-	if message.View == nil {
+	//	Make sure the message sender is ok
+	if !i.backend.IsValidValidator(message) {
 		return false
 	}
 


### PR DESCRIPTION
# Description

Previously, `isAcceptableMessage` called `i.backend.IsValidValidator(message)` before checking whether message or `message.View` were nil. This meant that if a message with a nil `View` was received, it could be passed into `IsValidValidator`, potentially causing a nil pointer dereference inside the backend implementation.

This fix reorders the checks so that the nil guards for message and message. `View` are evaluated first, ensuring `IsValidValidator` is only called with a well-formed message.

This PR also refactors `RunSequence` by extracting `runRound`. This is done because `Sonar` and `linter` because they required `defer cancelRound()` after `ctxRound, cancelRound := context.WithCancel(ctx)`

Unsupported `exportloopref` extension has been removed from `GolangCI` linter configuration 

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [X] I have added sufficient documentation in code

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
